### PR TITLE
Reverting version bump preventing installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "data-files-loader",
-	"version": "1.2.2",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {


### PR DESCRIPTION
I think there are two options for fixing #27 here:

1. Make a release for version 1.2.2 by pushing a tag (seems ideal to roll forward)
2. Revert the version bump to 1.2.1 (this PR) and people can still install the previous release

Apologies for breaking it with the version bump last time.

Edit: The manifest.json file has not been changed. I guess I don't understand how Obsidian is picking up versions.