### PR TITLE
Add JSONL (JSON Lines) file format support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,9 +2,11 @@ export const VIEW_TYPE_JSON = "json";
 export const VIEW_TYPE_XML = "xml";
 export const VIEW_TYPE_TXT = "txt";
 export const VIEW_TYPE_MARKDOWN = "markdown";
+export const VIEW_TYPE_JSONL = "jsonl";
 export const VIEW_TYPE_YAML = "yaml";
 
 export const EXT_JSON = "json";
+export const EXT_JSONL = "jsonl";
 export const EXT_XML = "xml";
 export const EXT_TXT = "txt";
 export const EXT_YAML = "yaml";

--- a/src/loader-plugin-settings.ts
+++ b/src/loader-plugin-settings.ts
@@ -5,6 +5,8 @@
 	doCreateXml: boolean;
 	doLoadJson: boolean;
 	doCreateJson: boolean;
+	doLoadJsonl: boolean;
+	doCreateJsonl: boolean;
 	doLoadYaml: boolean;
 	doCreateYaml: boolean;
 	doAutosaveFiles: boolean;
@@ -18,6 +20,8 @@ export const DEFAULT_SETTINGS: LoaderPluginSettings = {
 	doCreateXml: true,
 	doLoadJson: true,
 	doCreateJson: true,
+	doLoadJsonl: true,
+	doCreateJsonl: true,
 	doLoadYaml: true,
 	doCreateYaml: true,
 	doAutosaveFiles: true,

--- a/src/loader-settings-tab.ts
+++ b/src/loader-settings-tab.ts
@@ -55,6 +55,24 @@ export default class LoaderSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('Load .jsonl files')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.doLoadJsonl)
+				.onChange(async (value) => {
+					this.plugin.settings.doLoadJsonl = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Create .jsonl files')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.doCreateJsonl)
+				.onChange(async (value) => {
+					this.plugin.settings.doCreateJsonl = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName('Load .xml files')
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.doLoadXml)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import LoaderSettingTab from './loader-settings-tab';
 import * as constants from './constants'
 import {path} from "./utils";
 import JsonView from "./views/json-view";
+import JsonlView from "./views/jsonl-view";
 import TxtView from "./views/txt-view";
 import YamlView from "./views/yaml-view";
 import {DEFAULT_SETTINGS, LoaderPluginSettings} from "./loader-plugin-settings";
@@ -16,6 +17,8 @@ export default class LoaderPlugin extends Plugin {
 		this.TryRegisterTxt();
 
 		this.tryRegisterJson();
+
+		this.tryRegisterJsonl();
 
 		this.tryRegisterXml();
 
@@ -43,6 +46,16 @@ export default class LoaderPlugin extends Plugin {
 
 		if (this.settings.doCreateJson)
 			this.registerContextMenuCommand(constants.EXT_JSON);
+	}
+
+	private tryRegisterJsonl(): void {
+		if (this.settings.doLoadJsonl) {
+			this.registerView(constants.VIEW_TYPE_JSONL, (leaf: WorkspaceLeaf) => new JsonlView(leaf, this));
+			this.registerExtensions([constants.EXT_JSONL], constants.VIEW_TYPE_JSONL);
+		}
+
+		if (this.settings.doCreateJsonl)
+			this.registerContextMenuCommand(constants.EXT_JSONL);
 	}
 
 	private tryRegisterXml(): void {

--- a/src/utils/obsidian-utils.ts
+++ b/src/utils/obsidian-utils.ts
@@ -1,13 +1,15 @@
 ﻿import {App} from "obsidian";
 import BaseView from "../views/base-view";
-import {VIEW_TYPE_JSON, VIEW_TYPE_TXT, VIEW_TYPE_YAML} from "../constants";
+import {VIEW_TYPE_JSON, VIEW_TYPE_JSONL, VIEW_TYPE_TXT, VIEW_TYPE_YAML} from "../constants";
 import JsonView from "../views/json-view";
+import JsonlView from "../views/jsonl-view";
 import TxtView from "../views/txt-view";
 import YamlView from "../views/yaml-view";
 
 export function getLoaderViews(app: App): BaseView[] {
 	const leaves = [
 		...app.workspace.getLeavesOfType(VIEW_TYPE_JSON).filter(l => l.view instanceof JsonView),
+		...app.workspace.getLeavesOfType(VIEW_TYPE_JSONL).filter(l => l.view instanceof JsonlView),
 		...app.workspace.getLeavesOfType(VIEW_TYPE_TXT).filter(l => l.view instanceof TxtView),
 		...app.workspace.getLeavesOfType(VIEW_TYPE_YAML).filter(l => l.view instanceof YamlView),
 	];

--- a/src/views/jsonl-view.ts
+++ b/src/views/jsonl-view.ts
@@ -1,0 +1,27 @@
+import { WorkspaceLeaf } from "obsidian";
+import { json } from "@codemirror/lang-json";
+import { Extension } from "@codemirror/state";
+import { VIEW_TYPE_JSONL } from '../constants'
+import LoaderPlugin from "../main";
+import { getIndentByTabExtension } from "../services/indentation-provider"
+import BaseView from "./base-view";
+
+export default class JsonlView extends BaseView {
+	constructor(leaf: WorkspaceLeaf, plugin: LoaderPlugin) {
+		super(leaf, plugin);
+	}
+
+	getViewType(): string {
+		return VIEW_TYPE_JSONL;
+	}
+
+	protected getEditorExtensions(): Extension[] {
+		let extensions: Extension[];
+		extensions = [
+			getIndentByTabExtension(),
+			json()
+		];
+
+		return extensions;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `.jsonl` file loading, editing, and creation following the existing pattern for other formats
- Uses CodeMirror's JSON language support for syntax highlighting
- Includes settings toggles for load/create, consistent with existing format settings
- No new dependencies required — reuses `@codemirror/lang-json`

## Changes
- `constants.ts`: Added `VIEW_TYPE_JSONL` and `EXT_JSONL`
- `loader-plugin-settings.ts`: Added `doLoadJsonl` / `doCreateJsonl` settings (default: `true`)
- `views/jsonl-view.ts`: New view extending `BaseView` with JSON language extensions
- `main.ts`: Added `tryRegisterJsonl()` registration method
- `loader-settings-tab.ts`: Added Load/Create toggles for `.jsonl` files
- `utils/obsidian-utils.ts`: Added `JsonlView` to `getLoaderViews()`

## Test plan
- [ ] Open an existing `.jsonl` file in Obsidian — should open in the editor with JSON syntax highlighting
- [ ] Right-click a folder → "Create .jsonl file" should create a new `.jsonl` file
- [ ] Toggle load/create settings on/off in plugin settings
- [ ] Verify other file formats (JSON, YAML, TXT, XML) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)