### PR TITLE
Add view-only prettify toggle for JSON and JSONL files

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,9 +2,11 @@ export const VIEW_TYPE_JSON = "json";
 export const VIEW_TYPE_XML = "xml";
 export const VIEW_TYPE_TXT = "txt";
 export const VIEW_TYPE_MARKDOWN = "markdown";
+export const VIEW_TYPE_JSONL = "jsonl";
 export const VIEW_TYPE_YAML = "yaml";
 
 export const EXT_JSON = "json";
+export const EXT_JSONL = "jsonl";
 export const EXT_XML = "xml";
 export const EXT_TXT = "txt";
 export const EXT_YAML = "yaml";

--- a/src/loader-plugin-settings.ts
+++ b/src/loader-plugin-settings.ts
@@ -10,6 +10,7 @@
 	doLoadYaml: boolean;
 	doCreateYaml: boolean;
 	doAutosaveFiles: boolean;
+	defaultPrettify: boolean;
 	lineWrapping: boolean;
 }
 
@@ -25,5 +26,6 @@ export const DEFAULT_SETTINGS: LoaderPluginSettings = {
 	doLoadYaml: true,
 	doCreateYaml: true,
 	doAutosaveFiles: true,
+	defaultPrettify: false,
 	lineWrapping: true
 }

--- a/src/loader-plugin-settings.ts
+++ b/src/loader-plugin-settings.ts
@@ -5,6 +5,8 @@
 	doCreateXml: boolean;
 	doLoadJson: boolean;
 	doCreateJson: boolean;
+	doLoadJsonl: boolean;
+	doCreateJsonl: boolean;
 	doLoadYaml: boolean;
 	doCreateYaml: boolean;
 	doAutosaveFiles: boolean;
@@ -18,6 +20,8 @@ export const DEFAULT_SETTINGS: LoaderPluginSettings = {
 	doCreateXml: true,
 	doLoadJson: true,
 	doCreateJson: true,
+	doLoadJsonl: true,
+	doCreateJsonl: true,
 	doLoadYaml: true,
 	doCreateYaml: true,
 	doAutosaveFiles: true,

--- a/src/loader-settings-tab.ts
+++ b/src/loader-settings-tab.ts
@@ -109,6 +109,16 @@ export default class LoaderSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('Auto-prettify JSON/JSONL files on open')
+			.setDesc('When enabled, JSON and JSONL files are displayed formatted. The file on disk is not modified.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.defaultPrettify)
+				.onChange(async (value) => {
+					this.plugin.settings.defaultPrettify = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName('Enable autosave for files')
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.doAutosaveFiles)

--- a/src/loader-settings-tab.ts
+++ b/src/loader-settings-tab.ts
@@ -55,6 +55,24 @@ export default class LoaderSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('Load .jsonl files')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.doLoadJsonl)
+				.onChange(async (value) => {
+					this.plugin.settings.doLoadJsonl = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Create .jsonl files')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.doCreateJsonl)
+				.onChange(async (value) => {
+					this.plugin.settings.doCreateJsonl = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName('Load .xml files')
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.doLoadXml)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import LoaderSettingTab from './loader-settings-tab';
 import * as constants from './constants'
 import {path} from "./utils";
 import JsonView from "./views/json-view";
+import JsonlView from "./views/jsonl-view";
 import TxtView from "./views/txt-view";
 import YamlView from "./views/yaml-view";
 import {DEFAULT_SETTINGS, LoaderPluginSettings} from "./loader-plugin-settings";
@@ -16,6 +17,8 @@ export default class LoaderPlugin extends Plugin {
 		this.TryRegisterTxt();
 
 		this.tryRegisterJson();
+
+		this.tryRegisterJsonl();
 
 		this.tryRegisterXml();
 
@@ -43,6 +46,16 @@ export default class LoaderPlugin extends Plugin {
 
 		if (this.settings.doCreateJson)
 			this.registerContextMenuCommand(constants.EXT_JSON);
+	}
+
+	private tryRegisterJsonl(): void {
+		if (this.settings.doLoadJsonl) {
+			this.registerView(constants.VIEW_TYPE_JSONL, (leaf: WorkspaceLeaf) => new JsonlView(leaf, this));
+			this.registerExtensions([constants.EXT_JSONL], constants.VIEW_TYPE_JSONL);
+		}
+
+		if (this.settings.doCreateJsonl)
+			this.registerContextMenuCommand(constants.EXT_JSONL);
 	}
 
 	private tryRegisterXml(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import JsonView from "./views/json-view";
 import JsonlView from "./views/jsonl-view";
 import TxtView from "./views/txt-view";
 import YamlView from "./views/yaml-view";
+import BaseView from "./views/base-view";
 import {DEFAULT_SETTINGS, LoaderPluginSettings} from "./loader-plugin-settings";
 
 export default class LoaderPlugin extends Plugin {
@@ -23,6 +24,21 @@ export default class LoaderPlugin extends Plugin {
 		this.tryRegisterXml();
 
 		this.tryRegisterYaml();
+
+		this.addCommand({
+			id: 'toggle-prettify',
+			name: 'Toggle prettify for current file',
+			checkCallback: (checking: boolean) => {
+				const view = this.app.workspace.getActiveViewOfType(BaseView);
+				if (view && view.supportsPrettify()) {
+					if (!checking) {
+						view.togglePrettify();
+					}
+					return true;
+				}
+				return false;
+			}
+		});
 
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(new LoaderSettingTab(this.app, this));

--- a/src/utils/obsidian-utils.ts
+++ b/src/utils/obsidian-utils.ts
@@ -1,13 +1,15 @@
 ﻿import {App} from "obsidian";
 import BaseView from "../views/base-view";
-import {VIEW_TYPE_JSON, VIEW_TYPE_TXT, VIEW_TYPE_YAML} from "../constants";
+import {VIEW_TYPE_JSON, VIEW_TYPE_JSONL, VIEW_TYPE_TXT, VIEW_TYPE_YAML} from "../constants";
 import JsonView from "../views/json-view";
+import JsonlView from "../views/jsonl-view";
 import TxtView from "../views/txt-view";
 import YamlView from "../views/yaml-view";
 
 export function getLoaderViews(app: App): BaseView[] {
 	const leaves = [
 		...app.workspace.getLeavesOfType(VIEW_TYPE_JSON).filter(l => l.view instanceof JsonView),
+		...app.workspace.getLeavesOfType(VIEW_TYPE_JSONL).filter(l => l.view instanceof JsonlView),
 		...app.workspace.getLeavesOfType(VIEW_TYPE_TXT).filter(l => l.view instanceof TxtView),
 		...app.workspace.getLeavesOfType(VIEW_TYPE_YAML).filter(l => l.view instanceof YamlView),
 	];

--- a/src/views/base-view.ts
+++ b/src/views/base-view.ts
@@ -1,4 +1,4 @@
-﻿import {TextFileView, WorkspaceLeaf} from "obsidian";
+import {TextFileView, WorkspaceLeaf} from "obsidian";
 import LoaderPlugin from "../main";
 import {EditorView, KeyBinding, keymap, ViewUpdate} from "@codemirror/view";
 import {EditorState, Extension} from "@codemirror/state";
@@ -9,10 +9,16 @@ export default abstract class BaseView extends TextFileView {
 	public plugin: LoaderPlugin;
 	protected cmEditor: EditorView;
 	protected editorEl: any;
+	protected isPrettified: boolean = false;
+	private prettifyAction: HTMLElement | null = null;
+	private originalContent: string = '';
+	private hasEditedContent: boolean = false;
+	private suppressEditTracking: boolean = false;
 
 	protected constructor(leaf: WorkspaceLeaf, plugin: LoaderPlugin) {
 		super(leaf);
 		this.plugin = plugin;
+		this.isPrettified = plugin.settings.defaultPrettify && this.supportsPrettify();
 	}
 
 	onload(): void {
@@ -25,14 +31,37 @@ export default abstract class BaseView extends TextFileView {
 		});
 
 		this.app.workspace.trigger("codemirror", this.cmEditor);
+
+		if (this.supportsPrettify()) {
+			this.prettifyAction = this.addAction(
+				'braces',
+				this.isPrettified ? 'Minify (showing formatted)' : 'Prettify (showing raw)',
+				() => { this.togglePrettify(); }
+			);
+			this.updatePrettifyButton();
+		}
 	}
 
 	getViewData(): string {
-		return this.cmEditor.state.doc.toString();
+		const content = this.cmEditor.state.doc.toString();
+		if (this.isPrettified) {
+			if (this.hasEditedContent) {
+				return this.compactContent(content);
+			}
+			return this.originalContent;
+		}
+		return content;
 	}
 
 	setViewData(data: string, clear: boolean): void {
+		this.originalContent = data;
+		this.hasEditedContent = false;
+		if (this.isPrettified) {
+			data = this.prettifyContent(data);
+		}
+		this.suppressEditTracking = true;
 		this.cmEditor.dispatch({changes: {from: 0, to: this.cmEditor.state.doc.length, insert: data}});
+		this.suppressEditTracking = false;
 	}
 
 	clear(): void {
@@ -54,13 +83,17 @@ export default abstract class BaseView extends TextFileView {
 		if (this.plugin.settings.doAutosaveFiles) {
 			await this.save(false);
 		}
-		
+
 		const data = this.getViewData();
 		this.cmEditor.setState(this.createDefaultEditorState());
 		this.setViewData(data, false);
 	}
-	
+
 	protected onEditorUpdate(update: ViewUpdate): void {
+		if (update.docChanged && this.isPrettified && !this.suppressEditTracking) {
+			this.hasEditedContent = true;
+		}
+
 		if (!this.plugin.settings.doAutosaveFiles) {
 			return;
 		}
@@ -73,6 +106,55 @@ export default abstract class BaseView extends TextFileView {
 	abstract getViewType(): string;
 
 	protected abstract getEditorExtensions(): Extension[];
+
+	public supportsPrettify(): boolean {
+		return false;
+	}
+
+	protected prettifyContent(content: string): string {
+		return content;
+	}
+
+	protected compactContent(content: string): string {
+		return content;
+	}
+
+	public togglePrettify(): void {
+		const currentContent = this.cmEditor.state.doc.toString();
+		this.isPrettified = !this.isPrettified;
+
+		let newContent: string;
+		if (this.isPrettified) {
+			// Turning ON: capture current editor content as the original
+			this.originalContent = currentContent;
+			this.hasEditedContent = false;
+			newContent = this.prettifyContent(currentContent);
+		} else {
+			// Turning OFF: restore original if no edits, otherwise compact
+			if (this.hasEditedContent) {
+				newContent = this.compactContent(currentContent);
+			} else {
+				newContent = this.originalContent;
+			}
+			this.hasEditedContent = false;
+		}
+
+		this.suppressEditTracking = true;
+		this.cmEditor.dispatch({
+			changes: {from: 0, to: this.cmEditor.state.doc.length, insert: newContent}
+		});
+		this.suppressEditTracking = false;
+
+		this.updatePrettifyButton();
+	}
+
+	private updatePrettifyButton(): void {
+		if (this.prettifyAction) {
+			this.prettifyAction.setAttribute('aria-label',
+				this.isPrettified ? 'Minify (showing formatted)' : 'Prettify (showing raw)');
+			this.prettifyAction.toggleClass('is-active', this.isPrettified);
+		}
+	}
 
 	private createDefaultEditorState() {
 		return EditorState.create({
@@ -90,7 +172,7 @@ export default abstract class BaseView extends TextFileView {
 			extensions.push(EditorView.lineWrapping);
 		return extensions;
 	}
-	
+
 	private customHistoryKeymap: readonly KeyBinding[]  = [
 		{ win: "Ctrl-Shift-z", run: redo, preventDefault: true}
 	];

--- a/src/views/json-view.ts
+++ b/src/views/json-view.ts
@@ -14,14 +14,34 @@ export default class JsonView extends BaseView {
 	getViewType(): string {
 		return VIEW_TYPE_JSON;
 	}
-	
+
+	public supportsPrettify(): boolean {
+		return true;
+	}
+
+	protected prettifyContent(content: string): string {
+		try {
+			return JSON.stringify(JSON.parse(content), null, '\t');
+		} catch {
+			return content;
+		}
+	}
+
+	protected compactContent(content: string): string {
+		try {
+			return JSON.stringify(JSON.parse(content));
+		} catch {
+			return content;
+		}
+	}
+
     protected getEditorExtensions(): Extension[] {
 		let extensions: Extension[];
 		extensions = [
 			getIndentByTabExtension(),
 			json()
 		];
-		
+
 		return extensions;
     }
 }

--- a/src/views/jsonl-view.ts
+++ b/src/views/jsonl-view.ts
@@ -15,6 +15,38 @@ export default class JsonlView extends BaseView {
 		return VIEW_TYPE_JSONL;
 	}
 
+	public supportsPrettify(): boolean {
+		return true;
+	}
+
+	protected prettifyContent(content: string): string {
+		return content
+			.split('\n')
+			.filter(line => line.trim())
+			.map(line => {
+				try {
+					return JSON.stringify(JSON.parse(line), null, '\t');
+				} catch {
+					return line;
+				}
+			})
+			.join('\n\n');
+	}
+
+	protected compactContent(content: string): string {
+		return content
+			.split(/\n\n+/)
+			.filter(block => block.trim())
+			.map(block => {
+				try {
+					return JSON.stringify(JSON.parse(block));
+				} catch {
+					return block.trim();
+				}
+			})
+			.join('\n');
+	}
+
 	protected getEditorExtensions(): Extension[] {
 		let extensions: Extension[];
 		extensions = [

--- a/src/views/jsonl-view.ts
+++ b/src/views/jsonl-view.ts
@@ -1,0 +1,27 @@
+import { WorkspaceLeaf } from "obsidian";
+import { json } from "@codemirror/lang-json";
+import { Extension } from "@codemirror/state";
+import { VIEW_TYPE_JSONL } from '../constants'
+import LoaderPlugin from "../main";
+import { getIndentByTabExtension } from "../services/indentation-provider"
+import BaseView from "./base-view";
+
+export default class JsonlView extends BaseView {
+	constructor(leaf: WorkspaceLeaf, plugin: LoaderPlugin) {
+		super(leaf, plugin);
+	}
+
+	getViewType(): string {
+		return VIEW_TYPE_JSONL;
+	}
+
+	protected getEditorExtensions(): Extension[] {
+		let extensions: Extension[];
+		extensions = [
+			getIndentByTabExtension(),
+			json()
+		];
+
+		return extensions;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a prettify/minify toggle for JSON and JSONL files — **display-only, never mutates the file on disk**
- Per-file toggle button (braces icon) in the view header
- Global default setting: "Auto-prettify JSON/JSONL files on open"
- Command palette entry: "Toggle prettify for current file"

**Depends on #30 (JSONL support)**

## How it works
- Stores original file content on load
- When prettify is active: editor shows formatted content, but `getViewData()` returns the original file content unchanged
- Only if the user makes data edits while prettified does the save pipeline compact the edited content
- Toggling prettify off restores the exact original file content (byte-identical)
- Uses a suppression flag around programmatic editor dispatches so only real user keystrokes mark content as edited

## Changes
- `views/base-view.ts`: Added prettify infrastructure — `originalContent` tracking, `suppressEditTracking` flag, `addAction()` toggle button, virtual `supportsPrettify()`/`prettifyContent()`/`compactContent()` methods
- `views/json-view.ts`: JSON prettify (tab-indented) and compact (`JSON.stringify` round-trip)
- `views/jsonl-view.ts`: JSONL prettify (expand each record to multi-line, blank-line separated) and compact (one JSON per line)
- `loader-plugin-settings.ts`: Added `defaultPrettify` setting (default: `false`)
- `loader-settings-tab.ts`: Added "Auto-prettify JSON/JSONL files on open" toggle
- `main.ts`: Added "Toggle prettify for current file" command

## Test plan
- [ ] Open an already-formatted JSON file → toggle prettify on → toggle off → file on disk should be unchanged
- [ ] Open a compact JSON file → toggle prettify → verify indented display → verify file on disk stays compact
- [ ] Open a JSONL file → toggle prettify → verify each record expands to multi-line → verify file stays one-per-line on disk
- [ ] Edit content while prettified → save → verify edits are preserved in compact form on disk
- [ ] Enable "Auto-prettify" in settings → open a new JSON file → should open prettified
- [ ] Open malformed JSON → toggle prettify → no crash, content unchanged
- [ ] Verify TXT/YAML/XML files do not show the prettify button

🤖 Generated with [Claude Code](https://claude.com/claude-code)