### PR TITLE
Destroy CodeMirror EditorView when data file view closes

### DIFF
--- a/src/views/base-view.ts
+++ b/src/views/base-view.ts
@@ -47,6 +47,7 @@ export default abstract class BaseView extends TextFileView {
 	}
 
 	onClose(): Promise<void> {
+		this.cmEditor.destroy();
 		return super.onClose();
 	}
 


### PR DESCRIPTION
## Summary

This PR destroys the custom CodeMirror `EditorView` when `BaseView` is closed.

`BaseView` creates its own CodeMirror editor instance, but the view lifecycle did not explicitly call `destroy()`. Calling `this.cmEditor.destroy()` in `onClose()` lets CodeMirror release its DOM references, event handlers, extensions, and internal view state when the Obsidian view is closed.

## Change

- Add `this.cmEditor.destroy()` in `BaseView.onClose()` before delegating to `super.onClose()`.

## Why

Without explicitly destroying the `EditorView`, repeatedly opening and closing data file views can leave CodeMirror-owned resources alive longer than necessary. This is a small lifecycle cleanup that reduces the risk of memory leaks.

## Testing

- Built the plugin successfully.
- Verified the change is limited to the view close lifecycle.